### PR TITLE
Add ansible parameter to uninstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,13 @@ jobs:
     strategy:
       matrix:
         distro:
+          - rockylinux9
           - rockylinux8
           - centos7
+          - ubuntu2204
           - ubuntu2004
-          - ubuntu1804
+          - debian12
           - debian11
-          - debian10
-          - debian9
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,12 @@ jobs:
     strategy:
       matrix:
         distro:
-          - rockylinux9
+          # - rockylinux9
           - rockylinux8
           - centos7
-          - ubuntu2204
+          # - ubuntu2204
           - ubuntu2004
-          - debian12
+          # - debian12
           - debian11
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
       with:
           path: 'fccn.ansible_pakiti_client'
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     
     - name: Restore virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -47,10 +47,10 @@ jobs:
       with:
           path: 'fccn.ansible_pakiti_client'
     
-    - name: Setup Python
-      uses: actions/setup-python@v2
+    - name: Setup Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     
     - name: Restore virtualenv
       uses: syphar/restore-virtualenv@v1
@@ -79,10 +79,10 @@ jobs:
         with:
           path: 'fccn.ansible_pakiti_client'
 
-      - name: Set up Python 3.
-        uses: actions/setup-python@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.8'
 
       - name: Restore virtual environment
         uses: syphar/restore-virtualenv@v1

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,5 +7,5 @@ rules:
     level: warning
 
 ignore: |
-  venv/**
-  .github/**
+  venv
+  .github

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,5 +7,5 @@ rules:
     level: warning
 
 ignore: |
-  venv
-  .github
+  venv/**
+  .github/**

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ lint-yaml: ## lint yaml files
 .PHONY: lint-yaml
 
 lint-ansible: ## lint yaml files
-	ansible-lint -c .ansible-lint
+	ansible-lint -c .ansible-lint .
 .PHONY: lint-ansible
 
 lint: | lint-yaml lint-ansible

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ pakiti_install: true
 # if role will execute the pakiti software that sends information to the server
 pakiti_push: false
 
+# flags to indicate to uninstall
+pakiti_uninstall: false
+
 # when we want to have a way to only push, we can skip the cronjob creation on
 # the installation process
 pakiti_install_cron: true

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,0 +1,5 @@
+collections:
+  - name: community.docker
+    version: ">=1.2.0,<2"
+  - name: community.general
+    version: ">=2,<3"

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -1,3 +1,4 @@
+---
 collections:
   - name: community.docker
     version: ">=1.2.0,<2"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,5 +13,10 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
+  log: true
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+# lint:
+#   name: yamllint
+#   options:
+#     config-file: .yamllint.yml

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,6 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: Example assertion
-    assert:
-      that: true
+    - name: Example assertion
+      assert:
+        that: true

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,3 @@
-ansible-lint
-yamllint
-ansible
-molecule
-molecule[lint]
-molecule[docker]
+molecule==3.6.0
+markupsafe==2.0.1
+molecule-docker==1.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,5 @@
 molecule==3.6.0
+ansible-lint==4.1.0
+yamllint==1.26.3
 markupsafe==2.0.1
 molecule-docker==1.1.0

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,7 @@
     mode: u=rwX,g=rX,o=rX
     recurse: true
   changed_when: false
+  when: pakiti_install
   tags: pakiti
 
 - name: Checkout the pakiti-client repository
@@ -32,7 +33,7 @@
     force: true
     accept_hostkey: true
   changed_when: false
-  when: not ansible_check_mode
+  when: pakiti_install and not ansible_check_mode
   become: true
   become_user: "{{ pakiti_user }}"
   tags: pakiti
@@ -45,6 +46,7 @@
     group: "{{ pakiti_user }}"
     mode: u=rwX,g=rX,o=rX
     recurse: true
+  when: pakiti_install
   changed_when: false
   tags: pakiti
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - include_tasks: check-params.yml
   tags: pakiti
 
+- include_tasks: uninstall.yml
+  when: pakiti_uninstall
+  tags: pakiti
+
 - include_tasks: install.yml
   when: pakiti_install
   tags: pakiti

--- a/tasks/push.yml
+++ b/tasks/push.yml
@@ -1,6 +1,7 @@
 ---
-- name: Push data to pakiti server
-  command: "{{ pakiti_exec }}"  # noqa no-changed-when
+- name: Push data to pakiti server  # noqa no-changed-when
+  command: "{{ pakiti_exec }}"
   become: true
   become_user: '{{ pakiti_user }}'
+  changed_when: true
   tags: pakiti

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,0 +1,7 @@
+---
+- name: Delete previous pakiti folder
+  file:
+    path: "{{ pakiti_client_path }}"
+    state: absent
+  when: pakiti_uninstall
+  tags: pakiti


### PR DESCRIPTION
The new v3.0.4 tag was added, but it was edited after. This raises an error during an update of existing git folder. The solution is to add an option to delete existing checkout code. With this we can deploy with `--tags pakiti -e pakiti_uninstall=true` and it will delete and checkout again a fresh pakiti. Resolves #5