### PR TITLE
Fix warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The optional variables are defined on the [defaults/main.yml](defaults/main.yml)
 1. `github_repository` - git repository link that has the client installation data
 1. `pakiti_server_url` - URL that the client uses to send data
 1. `pakiti_exec` - client script that will be executed
+1. `pakiti_uninstall` - to uninstall pakiti (simply deletes the pakiti folder)
 
 ## Dependencies
 Only ansible and a way to elevate privileges to sudo or root, so that the role can install OS dependencies and create the user that will execute the client.

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -3,5 +3,5 @@
   file:
     path: "{{ pakiti_client_path }}"
     state: absent
-  when: pakiti_uninstall
+  when: pakiti_uninstall | bool
   tags: pakiti


### PR DESCRIPTION
[DEPRECATION WARNING]: evaluating true as a bare variable, this behaviour will
go away and you might need to add |bool to the expression in the future. Also
see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed
in version 2.12. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.