### PR TITLE
feat: add retry to push metrics to pakiti

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,6 @@ ansible-lint==4.1.0
 yamllint==1.26.3
 markupsafe==2.0.1
 molecule-docker==1.1.0
+
+# temp: https://github.com/docker/docker-py/issues/3256
+requests < 2.32.0

--- a/tasks/push.yml
+++ b/tasks/push.yml
@@ -4,4 +4,8 @@
   become: true
   become_user: '{{ pakiti_user }}'
   changed_when: true
+  retries: "{{ pakiti_push_retries | default(3) }}"
+  delay: "{{ pakiti_push_delay | default(3) }}"
+  register: pakiti_push_result
+  until: pakiti_push_result.rc == 0
   tags: pakiti


### PR DESCRIPTION
Add a retry with a delay when pushing metrics to pakiti server, so if occurs a sporadic connection problem, the playbook/role doen't crash.